### PR TITLE
feat: update to feathers 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
-        "@feathersjs/adapter-commons": "^4.5.11",
-        "@feathersjs/errors": "^4.5.11",
-        "@feathersjs/feathers": "^4.5.11",
-        "feathers-hooks-common": "^5.0.5",
+        "@feathersjs/adapter-commons": "5.0.0-pre.15",
+        "@feathersjs/errors": "5.0.0-pre.15",
+        "@feathersjs/feathers": "5.0.0-pre.15",
+        "feathers-hooks-common": "git+https://github.com/forgot/feathers-hooks-common.git#0c7546e2bbfc5873db82ecc30cbb701af58a90ab",
         "lodash": "^4.17.21",
         "type-fest": "^2.5.4"
       },
@@ -442,26 +442,39 @@
       }
     },
     "node_modules/@feathersjs/adapter-commons": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-4.5.11.tgz",
-      "integrity": "sha512-qJ+P/6GLR3KfXhzgRkvl3p66YmaTxLO1js1Jzs+d5QnnUYx+jWSV7tzYVZoVjQSlF8ht/zh9N5qfh0RV9w1E+w==",
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-5.0.0-pre.15.tgz",
+      "integrity": "sha512-93PsxOKqfeQNGQ0RcdgvkIS33hU7oKYkJTDH2gQw+afzCmE6Ypb137bDM9CVZbLIAFd/VIIOARL3VKtWC3acOg==",
       "dependencies": {
-        "@feathersjs/commons": "^4.5.11",
-        "@feathersjs/errors": "^4.5.11",
-        "@feathersjs/feathers": "^4.5.11"
+        "@feathersjs/commons": "^5.0.0-pre.15",
+        "@feathersjs/errors": "^5.0.0-pre.15",
+        "@feathersjs/feathers": "^5.0.0-pre.15"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/feathers"
       }
     },
+    "node_modules/@feathersjs/adapter-commons/node_modules/@feathersjs/commons": {
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.0-pre.15.tgz",
+      "integrity": "sha512-m81KMdWE5ses0jp74xUpwTFiJPSFh2PxotLv38MRBmuaE9H4aJpWfG3Yqtw44bZTWBo9199yG8kSSe5Ect1DYg==",
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/daffl"
+      }
+    },
     "node_modules/@feathersjs/commons": {
       "version": "4.5.11",
       "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.5.11.tgz",
       "integrity": "sha512-it/9lc0OER36+2zidopWo6Z4xRqNImQ+qegyQdHEuIDpEsYLXAv6MVHuDccaW2x2UmW5pce75UB7DhQ8yh8J/Q==",
+      "dev": true,
       "engines": {
         "node": ">= 10"
       },
@@ -471,32 +484,48 @@
       }
     },
     "node_modules/@feathersjs/errors": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-4.5.11.tgz",
-      "integrity": "sha512-KzkUqmaV7/SGK6SM/ILXjMI/EHOGKQE4GgDHCsB4+mcIwb8IZboeHL6IkYjh6MvwjKNDyS728McZvcflDGn/fA==",
-      "dependencies": {
-        "debug": "^4.3.1"
-      },
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-5.0.0-pre.15.tgz",
+      "integrity": "sha512-MuNZWN9FI8J2zBx+02fp3UlRxcZwvEaUrshTEiyFiEyb0PPY4m7h53K/0ps0IINimSha03LGwnNf1gxDJWkyDQ==",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/@feathersjs/feathers": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-4.5.11.tgz",
-      "integrity": "sha512-13zorhzi9eOwAW+l3oT4K8+CGCljpd9yPkx1XOZZyG5J1RSENWpPhgJ5Oe+qWw6Iqk768UBYp3+W1hLCQa6t2g==",
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-5.0.0-pre.15.tgz",
+      "integrity": "sha512-53ToWckg6csoaguLw0t3iG2rO109lZsbTrPv85RBKNnhd+ENyjW6+Kkw60Um17PC03n8uyb+5mGJr8paIVRBhg==",
       "dependencies": {
-        "@feathersjs/commons": "^4.5.11",
-        "debug": "^4.3.1",
-        "events": "^3.2.0",
-        "uberproto": "^2.0.6"
+        "@feathersjs/commons": "^5.0.0-pre.15",
+        "@feathersjs/hooks": "^0.6.5",
+        "events": "^3.3.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/daffl"
+      }
+    },
+    "node_modules/@feathersjs/feathers/node_modules/@feathersjs/commons": {
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.0-pre.15.tgz",
+      "integrity": "sha512-m81KMdWE5ses0jp74xUpwTFiJPSFh2PxotLv38MRBmuaE9H4aJpWfG3Yqtw44bZTWBo9199yG8kSSe5Ect1DYg==",
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/daffl"
+      }
+    },
+    "node_modules/@feathersjs/hooks": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@feathersjs/hooks/-/hooks-0.6.5.tgz",
+      "integrity": "sha512-WtcEoG/imdHRvC3vofGi/OcgH+cjHHhO0AfEeTlsnrKLjVKKBXV6aoIrB2nHZPpE7iW5sA7AZMR6bPD8ytxN+w==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1785,6 +1814,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2281,9 +2311,9 @@
       }
     },
     "node_modules/events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -2368,23 +2398,52 @@
       }
     },
     "node_modules/feathers-hooks-common": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/feathers-hooks-common/-/feathers-hooks-common-5.0.5.tgz",
-      "integrity": "sha512-GOHZ6W/ioEK5uCs4bCh21P/oLObVqIkbQ6WTKZMscJlykDptH3KOIMiUpFscO6uLQcKKZHY7a1PabLNFP2J7tA==",
+      "version": "5.0.6",
+      "resolved": "git+ssh://git@github.com/forgot/feathers-hooks-common.git#0c7546e2bbfc5873db82ecc30cbb701af58a90ab",
+      "integrity": "sha512-EnyaRlkBaJ5WBSiKpQxr1NJ3PvvxpFFsY/FgwJyc1bxkvFv0PN9yw115HYYhFTdrIEJzuEHVfEA5f+5D0iowCQ==",
+      "license": "MIT",
       "dependencies": {
         "@feathers-plus/batch-loader": "^0.3.6",
-        "@feathersjs/commons": "^4.5.11",
-        "@feathersjs/errors": "^4.5.11",
-        "@feathersjs/feathers": "^4.5.11",
+        "@feathersjs/commons": "^5.0.0-pre.9",
+        "@feathersjs/errors": "^5.0.0-pre.9",
+        "@feathersjs/feathers": "^5.0.0-pre.9",
         "ajv": "^6.12.6",
-        "debug": "^4.3.1",
-        "graphql": "^15.5.0",
-        "lodash": "^4.17.20",
+        "debug": "^4.3.2",
+        "graphql": "^15.5.1",
+        "lodash": "^4.17.21",
         "process": "0.11.10",
         "traverse": "^0.6.6"
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/feathers-hooks-common/node_modules/@feathersjs/commons": {
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.0-pre.15.tgz",
+      "integrity": "sha512-m81KMdWE5ses0jp74xUpwTFiJPSFh2PxotLv38MRBmuaE9H4aJpWfG3Yqtw44bZTWBo9199yG8kSSe5Ect1DYg==",
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/daffl"
+      }
+    },
+    "node_modules/feathers-hooks-common/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/feathers-memory": {
@@ -2400,6 +2459,55 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/feathers-memory/node_modules/@feathersjs/adapter-commons": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-4.5.11.tgz",
+      "integrity": "sha512-qJ+P/6GLR3KfXhzgRkvl3p66YmaTxLO1js1Jzs+d5QnnUYx+jWSV7tzYVZoVjQSlF8ht/zh9N5qfh0RV9w1E+w==",
+      "dev": true,
+      "dependencies": {
+        "@feathersjs/commons": "^4.5.11",
+        "@feathersjs/errors": "^4.5.11",
+        "@feathersjs/feathers": "^4.5.11"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/feathers"
+      }
+    },
+    "node_modules/feathers-memory/node_modules/@feathersjs/errors": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-4.5.11.tgz",
+      "integrity": "sha512-KzkUqmaV7/SGK6SM/ILXjMI/EHOGKQE4GgDHCsB4+mcIwb8IZboeHL6IkYjh6MvwjKNDyS728McZvcflDGn/fA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/feathers-memory/node_modules/@feathersjs/feathers": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-4.5.11.tgz",
+      "integrity": "sha512-13zorhzi9eOwAW+l3oT4K8+CGCljpd9yPkx1XOZZyG5J1RSENWpPhgJ5Oe+qWw6Iqk768UBYp3+W1hLCQa6t2g==",
+      "dev": true,
+      "dependencies": {
+        "@feathersjs/commons": "^4.5.11",
+        "debug": "^4.3.1",
+        "events": "^3.2.0",
+        "uberproto": "^2.0.6"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/daffl"
       }
     },
     "node_modules/figures": {
@@ -2769,9 +2877,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
       "engines": {
         "node": ">= 10.x"
       }
@@ -6874,6 +6982,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-2.0.6.tgz",
       "integrity": "sha512-68H97HffZoFaa3HFtpstahWorN9dSp5uTU6jo3GjIQ6JkJBR3hC2Nx/e/HFOoYHdUyT/Z1MRWfxN1EiQJZUyCQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7661,38 +7770,54 @@
       "integrity": "sha512-r+n31iZ/B5Rl1mLkC9/S20UI445MdkZvE3VBmjupep2t8OuyTYHPkFEgR25HY6khH+RothK1VL3B5eumk9N2QQ=="
     },
     "@feathersjs/adapter-commons": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-4.5.11.tgz",
-      "integrity": "sha512-qJ+P/6GLR3KfXhzgRkvl3p66YmaTxLO1js1Jzs+d5QnnUYx+jWSV7tzYVZoVjQSlF8ht/zh9N5qfh0RV9w1E+w==",
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-5.0.0-pre.15.tgz",
+      "integrity": "sha512-93PsxOKqfeQNGQ0RcdgvkIS33hU7oKYkJTDH2gQw+afzCmE6Ypb137bDM9CVZbLIAFd/VIIOARL3VKtWC3acOg==",
       "requires": {
-        "@feathersjs/commons": "^4.5.11",
-        "@feathersjs/errors": "^4.5.11",
-        "@feathersjs/feathers": "^4.5.11"
+        "@feathersjs/commons": "^5.0.0-pre.15",
+        "@feathersjs/errors": "^5.0.0-pre.15",
+        "@feathersjs/feathers": "^5.0.0-pre.15"
+      },
+      "dependencies": {
+        "@feathersjs/commons": {
+          "version": "5.0.0-pre.15",
+          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.0-pre.15.tgz",
+          "integrity": "sha512-m81KMdWE5ses0jp74xUpwTFiJPSFh2PxotLv38MRBmuaE9H4aJpWfG3Yqtw44bZTWBo9199yG8kSSe5Ect1DYg=="
+        }
       }
     },
     "@feathersjs/commons": {
       "version": "4.5.11",
       "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.5.11.tgz",
-      "integrity": "sha512-it/9lc0OER36+2zidopWo6Z4xRqNImQ+qegyQdHEuIDpEsYLXAv6MVHuDccaW2x2UmW5pce75UB7DhQ8yh8J/Q=="
+      "integrity": "sha512-it/9lc0OER36+2zidopWo6Z4xRqNImQ+qegyQdHEuIDpEsYLXAv6MVHuDccaW2x2UmW5pce75UB7DhQ8yh8J/Q==",
+      "dev": true
     },
     "@feathersjs/errors": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-4.5.11.tgz",
-      "integrity": "sha512-KzkUqmaV7/SGK6SM/ILXjMI/EHOGKQE4GgDHCsB4+mcIwb8IZboeHL6IkYjh6MvwjKNDyS728McZvcflDGn/fA==",
-      "requires": {
-        "debug": "^4.3.1"
-      }
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-5.0.0-pre.15.tgz",
+      "integrity": "sha512-MuNZWN9FI8J2zBx+02fp3UlRxcZwvEaUrshTEiyFiEyb0PPY4m7h53K/0ps0IINimSha03LGwnNf1gxDJWkyDQ=="
     },
     "@feathersjs/feathers": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-4.5.11.tgz",
-      "integrity": "sha512-13zorhzi9eOwAW+l3oT4K8+CGCljpd9yPkx1XOZZyG5J1RSENWpPhgJ5Oe+qWw6Iqk768UBYp3+W1hLCQa6t2g==",
+      "version": "5.0.0-pre.15",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-5.0.0-pre.15.tgz",
+      "integrity": "sha512-53ToWckg6csoaguLw0t3iG2rO109lZsbTrPv85RBKNnhd+ENyjW6+Kkw60Um17PC03n8uyb+5mGJr8paIVRBhg==",
       "requires": {
-        "@feathersjs/commons": "^4.5.11",
-        "debug": "^4.3.1",
-        "events": "^3.2.0",
-        "uberproto": "^2.0.6"
+        "@feathersjs/commons": "^5.0.0-pre.15",
+        "@feathersjs/hooks": "^0.6.5",
+        "events": "^3.3.0"
+      },
+      "dependencies": {
+        "@feathersjs/commons": {
+          "version": "5.0.0-pre.15",
+          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.0-pre.15.tgz",
+          "integrity": "sha512-m81KMdWE5ses0jp74xUpwTFiJPSFh2PxotLv38MRBmuaE9H4aJpWfG3Yqtw44bZTWBo9199yG8kSSe5Ect1DYg=="
+        }
       }
+    },
+    "@feathersjs/hooks": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@feathersjs/hooks/-/hooks-0.6.5.tgz",
+      "integrity": "sha512-WtcEoG/imdHRvC3vofGi/OcgH+cjHHhO0AfEeTlsnrKLjVKKBXV6aoIrB2nHZPpE7iW5sA7AZMR6bPD8ytxN+w=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -8643,6 +8768,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -9015,9 +9141,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "execa": {
       "version": "5.1.1",
@@ -9087,20 +9213,35 @@
       }
     },
     "feathers-hooks-common": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/feathers-hooks-common/-/feathers-hooks-common-5.0.5.tgz",
-      "integrity": "sha512-GOHZ6W/ioEK5uCs4bCh21P/oLObVqIkbQ6WTKZMscJlykDptH3KOIMiUpFscO6uLQcKKZHY7a1PabLNFP2J7tA==",
+      "version": "git+ssh://git@github.com/forgot/feathers-hooks-common.git#0c7546e2bbfc5873db82ecc30cbb701af58a90ab",
+      "integrity": "sha512-EnyaRlkBaJ5WBSiKpQxr1NJ3PvvxpFFsY/FgwJyc1bxkvFv0PN9yw115HYYhFTdrIEJzuEHVfEA5f+5D0iowCQ==",
+      "from": "feathers-hooks-common@git+https://github.com/forgot/feathers-hooks-common.git#0c7546e2bbfc5873db82ecc30cbb701af58a90ab",
       "requires": {
         "@feathers-plus/batch-loader": "^0.3.6",
-        "@feathersjs/commons": "^4.5.11",
-        "@feathersjs/errors": "^4.5.11",
-        "@feathersjs/feathers": "^4.5.11",
+        "@feathersjs/commons": "^5.0.0-pre.9",
+        "@feathersjs/errors": "^5.0.0-pre.9",
+        "@feathersjs/feathers": "^5.0.0-pre.9",
         "ajv": "^6.12.6",
-        "debug": "^4.3.1",
-        "graphql": "^15.5.0",
-        "lodash": "^4.17.20",
+        "debug": "^4.3.2",
+        "graphql": "^15.5.1",
+        "lodash": "^4.17.21",
         "process": "0.11.10",
         "traverse": "^0.6.6"
+      },
+      "dependencies": {
+        "@feathersjs/commons": {
+          "version": "5.0.0-pre.15",
+          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.0-pre.15.tgz",
+          "integrity": "sha512-m81KMdWE5ses0jp74xUpwTFiJPSFh2PxotLv38MRBmuaE9H4aJpWfG3Yqtw44bZTWBo9199yG8kSSe5Ect1DYg=="
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "feathers-memory": {
@@ -9113,6 +9254,40 @@
         "@feathersjs/commons": "^4.3.0",
         "@feathersjs/errors": "^4.3.4",
         "sift": "^8.5.0"
+      },
+      "dependencies": {
+        "@feathersjs/adapter-commons": {
+          "version": "4.5.11",
+          "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-4.5.11.tgz",
+          "integrity": "sha512-qJ+P/6GLR3KfXhzgRkvl3p66YmaTxLO1js1Jzs+d5QnnUYx+jWSV7tzYVZoVjQSlF8ht/zh9N5qfh0RV9w1E+w==",
+          "dev": true,
+          "requires": {
+            "@feathersjs/commons": "^4.5.11",
+            "@feathersjs/errors": "^4.5.11",
+            "@feathersjs/feathers": "^4.5.11"
+          }
+        },
+        "@feathersjs/errors": {
+          "version": "4.5.11",
+          "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-4.5.11.tgz",
+          "integrity": "sha512-KzkUqmaV7/SGK6SM/ILXjMI/EHOGKQE4GgDHCsB4+mcIwb8IZboeHL6IkYjh6MvwjKNDyS728McZvcflDGn/fA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1"
+          }
+        },
+        "@feathersjs/feathers": {
+          "version": "4.5.11",
+          "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-4.5.11.tgz",
+          "integrity": "sha512-13zorhzi9eOwAW+l3oT4K8+CGCljpd9yPkx1XOZZyG5J1RSENWpPhgJ5Oe+qWw6Iqk768UBYp3+W1hLCQa6t2g==",
+          "dev": true,
+          "requires": {
+            "@feathersjs/commons": "^4.5.11",
+            "debug": "^4.3.1",
+            "events": "^3.2.0",
+            "uberproto": "^2.0.6"
+          }
+        }
       }
     },
     "figures": {
@@ -9366,9 +9541,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
     },
     "growl": {
       "version": "1.10.5",
@@ -12443,7 +12618,8 @@
     "uberproto": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-2.0.6.tgz",
-      "integrity": "sha512-68H97HffZoFaa3HFtpstahWorN9dSp5uTU6jo3GjIQ6JkJBR3hC2Nx/e/HFOoYHdUyT/Z1MRWfxN1EiQJZUyCQ=="
+      "integrity": "sha512-68H97HffZoFaa3HFtpstahWorN9dSp5uTU6jo3GjIQ6JkJBR3hC2Nx/e/HFOoYHdUyT/Z1MRWfxN1EiQJZUyCQ==",
+      "dev": true
     },
     "unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@feathersjs/adapter-commons": "^4.5.11",
-    "@feathersjs/errors": "^4.5.11",
-    "@feathersjs/feathers": "^4.5.11",
-    "feathers-hooks-common": "^5.0.5",
+    "@feathersjs/adapter-commons": "5.0.0-pre.15",
+    "@feathersjs/errors": "5.0.0-pre.15",
+    "@feathersjs/feathers": "5.0.0-pre.15",
+    "feathers-hooks-common": "git+https://github.com/forgot/feathers-hooks-common.git#0c7546e2bbfc5873db82ecc30cbb701af58a90ab",
     "lodash": "^4.17.21",
     "type-fest": "^2.5.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export { checkMulti };
 export { setData };
 export { runPerItem };
 
-import { debounceMixin, DebouncedStore } from "./mixins/debounce-mixin";
+import { debounceMixin, DebouncedService, DebouncedStore } from "./mixins/debounce-mixin";
 
 export const mixins = {
   debounceMixin,
@@ -21,6 +21,7 @@ export const mixins = {
 };
 
 export { debounceMixin };
+export { DebouncedService };
 export { DebouncedStore };
 
 export { addHook } from "./utils/addHook";

--- a/src/mixins/debounce-mixin/index.ts
+++ b/src/mixins/debounce-mixin/index.ts
@@ -3,18 +3,22 @@ import {
   makeDefaultOptions
 } from "./DebouncedStore";
 
-import type { Application } from "@feathersjs/feathers";
+import type { Application, FeathersService } from "@feathersjs/feathers";
 
 import type {
   InitDebounceMixinOptions,
   DebouncedStoreOptions,
 } from "../../types";
 
+export type DebouncedService = FeathersService & {
+  debouncedStore?: DebouncedStore;
+};
+
 export function debounceMixin(options?: Partial<InitDebounceMixinOptions>): ((app: Application) => void) {
   return (app: Application): void => {
     options = options || {};
     const defaultOptions = Object.assign(makeDefaultOptions(), options?.default);
-    app.mixins.push((service, path) => {
+    app.mixins.push((service: DebouncedService, path) => {
       // if path is on blacklist, don't add debouncedStore to service
       if (options?.blacklist && options.blacklist.includes(path)) return;
       // if service already has registered something on `debouncedStore`

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import type { Application, Service } from "@feathersjs/feathers";
+import type { Application } from "@feathersjs/feathers";
+import type { AdapterService } from "@feathersjs/adapter-commons";
 
 export type Path = Array<string|number>;
 export type HookType = "before" | "after" | "error";
@@ -69,7 +70,7 @@ export interface MergeQueryOptions<T> extends FilterQueryOptions<T> {
 }
 
 export interface FilterQueryOptions<T> {
-  service?: Service<T>
+  service?: AdapterService<T>
   operators?: string[],
   filters?: string[],
 }

--- a/src/utils/addHook.ts
+++ b/src/utils/addHook.ts
@@ -42,7 +42,8 @@ export const addHook = (app: Application, hook: unknown, options: AddHookOptions
       const order = orderByType[type];
       const unshiftOrPush = (order === "first") ? "unshift" : "push";
       methods.forEach(method => {
-        service.__hooks[type][method][unshiftOrPush](hook);
+        // TODO: adjust to new feathers interals
+        // service.__hooks[type][method][unshiftOrPush](hook);
       });
     });
   }

--- a/src/utils/filterQuery.ts
+++ b/src/utils/filterQuery.ts
@@ -25,7 +25,7 @@ export function filterQuery<T>(query: Query, options?: FilterQueryOptions<T>): F
     if (operators) { optionsForFilterQuery.operators = operators; }
     if (filters) { optionsForFilterQuery.filters = filters; }
     if (typeof service?.filterQuery === "function") {
-      return service.filterQuery({ query }, optionsForFilterQuery);
+      return service.filterQuery({ query }, optionsForFilterQuery) as FilterQueryResult;
     } else {
       return plainFilterQuery(query, optionsForFilterQuery) as FilterQueryResult;
     }

--- a/src/utils/getPaginate.ts
+++ b/src/utils/getPaginate.ts
@@ -1,4 +1,11 @@
-import { HookContext, PaginationOptions } from "@feathersjs/feathers";
+import { HookContext } from "@feathersjs/feathers";
+
+// TODO: seems like this does no longer exist in feathers
+interface PaginationOptions {
+  default: number;
+  max: number;
+}
+
 
 export const getPaginate = (
   context: HookContext

--- a/test/mixins/debounce-mixin.test.ts
+++ b/test/mixins/debounce-mixin.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
-import feathers from "@feathersjs/feathers";
+import { feathers } from "@feathersjs/feathers";
 import createService from "feathers-memory";
-import { debounceMixin as makeMixin } from "../../src";
+import { DebouncedService, debounceMixin as makeMixin } from "../../src";
 import { performance } from "perf_hooks";
 
 const mockApp = () => {
@@ -19,10 +19,10 @@ const mockApp = () => {
 
   app.use("authentication", createService());
 
-  const usersService = app.service("users");
-  const tasksService = app.service("tasks");
-  const postsService = app.service("posts");
-  const authenticationService = app.service("authentication");
+  const usersService: DebouncedService = app.service("users");
+  const tasksService: DebouncedService = app.service("tasks");
+  const postsService: DebouncedService = app.service("posts");
+  const authenticationService: DebouncedService = app.service("authentication");
 
   return {
     app,
@@ -67,6 +67,7 @@ describe("mixin: debounce-mixin", function() {
     assert.strictEqual(items[0].id, 49, "called with last iteration");
     assert.strictEqual(callCounter, 1, "only called once");
     assert.deepStrictEqual(usersService.debouncedStore._queueById, {}, "queue is empty");
+    // @ts-ignore access to private property
     assert.deepStrictEqual(usersService.debouncedStore._isRunningById, {}, "nothing is running");
   });
 

--- a/test/utils/addHook.test.ts
+++ b/test/utils/addHook.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { feathers } from "@feathersjs/feathers";
+import { feathers, FeathersService } from "@feathersjs/feathers";
 import createService from "feathers-memory";
 
 import { addHook } from "../../src";
@@ -11,9 +11,12 @@ const mockApp = (withHooks?: boolean) => {
   app.use("users", createService());
   app.use("tasks", createService());
   app.use("authentication", createService());
-  const usersService = app.service("users");
-  const tasksService = app.service("tasks");
-  const authenticationService = app.service("authentication");
+  type ServiceWithPath = FeathersService & {
+    path?: string;
+  };
+  const usersService: ServiceWithPath = app.service("users");
+  const tasksService: ServiceWithPath = app.service("tasks");
+  const authenticationService: ServiceWithPath = app.service("authentication");
   usersService.path = "users";
   tasksService.path = "tasks";
   authenticationService.path = "authentication";

--- a/test/utils/addHook.test.ts
+++ b/test/utils/addHook.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import feathers from "@feathersjs/feathers";
+import { feathers } from "@feathersjs/feathers";
 import createService from "feathers-memory";
 
 import { addHook } from "../../src";

--- a/test/utils/markHookForSkip.test.ts
+++ b/test/utils/markHookForSkip.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import feathers from "@feathersjs/feathers";
+import { feathers } from "@feathersjs/feathers";
 import { Service } from "feathers-memory";
 import { shouldSkip, markHookForSkip } from "../../src";
 

--- a/test/utils/mergeQuery.test.ts
+++ b/test/utils/mergeQuery.test.ts
@@ -1,6 +1,6 @@
 import assert from"assert";
 import { mergeQuery } from "../../src";
-import feathers from "@feathersjs/feathers";
+import { feathers } from "@feathersjs/feathers";
 import { Service } from "feathers-memory";
 
 describe("util - mergeQuery", function() {


### PR DESCRIPTION
This updates feathers to version 5.

Updating feathers here is related to https://github.com/fratzinger/feathers-casl/issues/48.

## TODO

- [ ] `PaginationOptions` does not seem to exist in feathers 5
- [ ] `service.__hooks` does not exist
- [x] `service.path` does not exist