### PR TITLE
!refactor(filterQuery): custom easy filterQuery

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -13,4 +13,7 @@ export default defineBuildConfig({
   rollup: {
     emitCJS: true,
   },
+  replace: {
+    "import.meta.vitest": "undefined",
+  },
 });

--- a/src/utils/filterQuery.ts
+++ b/src/utils/filterQuery.ts
@@ -1,45 +1,98 @@
-import { filterQuery as plainFilterQuery } from "@feathersjs/adapter-commons";
-
-import type {
-  FilterQueryOptions as PlainFilterQueryOptions,
-  AdapterBase,
-} from "@feathersjs/adapter-commons";
-
 import type { Query } from "@feathersjs/feathers";
 
-export interface FilterQueryOptions<T> {
-  service?: AdapterBase<T>;
-  operators?: PlainFilterQueryOptions["operators"];
-  filters?: PlainFilterQueryOptions["filters"];
+type FilterQueryResult<Q extends Query> = {
+  $select: Q["$select"] extends any ? Q["$select"] : never;
+  $limit: Q["$limit"] extends any ? Q["$limit"] : never;
+  $skip: Q["$skip"] extends any ? Q["$skip"] : never;
+  $sort: Q["$sort"] extends any ? Q["$sort"] : never;
+  query: Omit<Q, "$select" | "$limit" | "$skip" | "$sort">;
+};
+
+/**
+ * Extracts $select, $limit, $skip, $sort from a query and returns the rest as a query object.
+ *
+ * @param providedQuery
+ * @returns
+ */
+export function filterQuery<Q extends Query>(
+  providedQuery?: Q,
+): FilterQueryResult<Q> {
+  providedQuery ??= {} as Q;
+  const { $select, $limit, $skip, $sort, ...query } = providedQuery;
+
+  const result: FilterQueryResult<Q> = { query } as any;
+
+  if ("$select" in providedQuery) {
+    result.$select = $select;
+  }
+
+  if ("$limit" in providedQuery) {
+    result.$limit = $limit;
+  }
+
+  if ("$skip" in providedQuery) {
+    result.$skip = $skip;
+  }
+
+  if ("$sort" in providedQuery) {
+    result.$sort = $sort;
+  }
+
+  return result;
 }
 
-export function filterQuery<T>(query: Query, _options?: FilterQueryOptions<T>) {
-  query = query || {};
-  _options = _options || {};
-  const { service, ...options } = _options;
-  if (service) {
-    const operators = options.operators
-      ? options.operators
-      : service.options?.operators;
-    const filters = options.filters
-      ? options.filters
-      : service.options?.filters;
-    const optionsForFilterQuery: PlainFilterQueryOptions = {};
-    if (operators) {
-      optionsForFilterQuery.operators = operators;
-    }
-    if (filters) {
-      optionsForFilterQuery.filters = filters;
-    }
-    if (
-      service &&
-      "filterQuery" in service &&
-      typeof service.filterQuery === "function"
-    ) {
-      return service.filterQuery({ query }, optionsForFilterQuery);
-    } else {
-      return plainFilterQuery(query, optionsForFilterQuery);
-    }
-  }
-  return plainFilterQuery(query, options);
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest;
+
+  it("should filter query", () => {
+    const query = {
+      $select: ["a"],
+      $limit: 10,
+      $skip: 10,
+      $sort: {
+        a: 1,
+      },
+      a: 1,
+      b: 2,
+    };
+
+    expect(filterQuery(query)).toEqual({
+      $select: ["a"],
+      $limit: 10,
+      $skip: 10,
+      $sort: {
+        a: 1,
+      },
+      query: {
+        a: 1,
+        b: 2,
+      },
+    });
+  });
+
+  it("should not include filters if not provided", () => {
+    const query = {
+      a: 1,
+      b: 2,
+    };
+
+    expect(filterQuery(query)).toEqual({
+      query: {
+        a: 1,
+        b: 2,
+      },
+    });
+  });
+
+  it("sets empty query object if empty object is provided", () => {
+    expect(filterQuery({})).toEqual({
+      query: {},
+    });
+  });
+
+  it("sets empty query object if undefined is provided", () => {
+    expect(filterQuery(undefined)).toEqual({
+      query: {},
+    });
+  });
 }

--- a/src/utils/mergeQuery/mergeQuery.ts
+++ b/src/utils/mergeQuery/mergeQuery.ts
@@ -7,7 +7,6 @@ import {
   handleCircular,
   isQueryMoreExplicitThanQuery,
   makeDefaultOptions,
-  moveProperty,
 } from "./utils";
 import type { MergeQueryOptions } from "./types";
 import { filterQuery } from "../filterQuery";

--- a/src/utils/mergeQuery/mergeQuery.ts
+++ b/src/utils/mergeQuery/mergeQuery.ts
@@ -26,52 +26,13 @@ export function mergeQuery<T = any>(
   _options?: Partial<MergeQueryOptions<T>>,
 ): Query {
   const options = makeDefaultOptions(_options);
-  const { filters: targetFilters, query: targetQuery } = filterQuery(target, {
-    operators: options.operators,
-    filters: options.filters,
-    service: options.service,
-  });
 
-  moveProperty(targetFilters, targetQuery, "$or", "$and");
+  const { query: targetQuery, ...targetFilters } = filterQuery(target);
 
-  if ("$limit" in target) {
-    targetFilters.$limit = target.$limit;
-  }
-
-  let {
-    // eslint-disable-next-line prefer-const
-    filters: sourceFilters,
-    query: sourceQuery,
-  } = filterQuery(source, {
-    operators: options.operators,
-    filters: options.filters,
-    service: options.service,
-  });
-
-  moveProperty(sourceFilters, sourceQuery, "$or", "$and");
-
-  if (source.$limit) {
-    sourceFilters.$limit = source.$limit;
-  }
+  // eslint-disable-next-line prefer-const
+  let { query: sourceQuery, ...sourceFilters } = filterQuery(source);
 
   //#region filters
-
-  if (
-    target &&
-    !hasOwnProperty(target, "$limit") &&
-    hasOwnProperty(targetFilters, "$limit")
-  ) {
-    delete targetFilters.$limit;
-  }
-
-  if (
-    source &&
-    !hasOwnProperty(source, "$limit") &&
-    hasOwnProperty(sourceFilters, "$limit")
-  ) {
-    delete sourceFilters.$limit;
-  }
-
   handleArray(targetFilters, sourceFilters, ["$select"], options);
   // remaining filters
   delete sourceFilters["$select"];

--- a/src/utils/mergeQuery/mergeQuery.ts
+++ b/src/utils/mergeQuery/mergeQuery.ts
@@ -19,10 +19,10 @@ import { hasOwnProperty } from "../internal.utils";
  * @param _options
  * @returns Query
  */
-export function mergeQuery<T = any>(
+export function mergeQuery(
   target: Query,
   source: Query,
-  _options?: Partial<MergeQueryOptions<T>>,
+  _options?: Partial<MergeQueryOptions>,
 ): Query {
   const options = makeDefaultOptions(_options);
 

--- a/src/utils/mergeQuery/types.ts
+++ b/src/utils/mergeQuery/types.ts
@@ -1,5 +1,4 @@
 import type { Path } from "../../typesInternal";
-import type { FilterQueryOptions } from "../filterQuery";
 
 export type Handle =
   | "target"
@@ -15,7 +14,7 @@ export type ActionOnEmptyIntersect = (
   prependKey: Path,
 ) => void;
 
-export interface MergeQueryOptions<T> extends FilterQueryOptions<T> {
+export interface MergeQueryOptions {
   defaultHandle: Handle;
   actionOnEmptyIntersect: ActionOnEmptyIntersect;
   useLogicalConjunction: boolean;

--- a/src/utils/mergeQuery/utils.ts
+++ b/src/utils/mergeQuery/utils.ts
@@ -12,11 +12,11 @@ import { deepEqual as _isEqual } from "fast-equals";
 import type { Query } from "@feathersjs/feathers";
 import { hasOwnProperty } from "../internal.utils";
 
-export function handleArray<T>(
+export function handleArray(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
   key: Path,
-  options: MergeQueryOptions<T>,
+  options: MergeQueryOptions,
 ): void {
   const targetVal = _get(target, key);
   const sourceVal = _get(source, key);
@@ -42,7 +42,7 @@ export function handleCircular<T>(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
   prependKey: Path,
-  options: MergeQueryOptions<T>,
+  options: MergeQueryOptions,
 ): void {
   if (target?.$or) {
     target.$or = cleanOr(target.$or as Record<string, unknown>[]);
@@ -257,10 +257,10 @@ export function handleCircular<T>(
   }
 }
 
-export function makeDefaultOptions<T>(
-  options?: Partial<MergeQueryOptions<T>>,
-): MergeQueryOptions<T> {
-  options ??= {} as MergeQueryOptions<T>;
+export function makeDefaultOptions(
+  options?: Partial<MergeQueryOptions>,
+): MergeQueryOptions {
+  options ??= {} as MergeQueryOptions;
   options.defaultHandle ??= "combine";
   options.useLogicalConjunction ??= false;
   options.actionOnEmptyIntersect ??= () => {
@@ -270,7 +270,7 @@ export function makeDefaultOptions<T>(
   if (options.defaultHandle === "intersect") {
     options.handle.$select = options.handle.$select || "intersectOrFull";
   }
-  return options as MergeQueryOptions<T>;
+  return options as MergeQueryOptions;
 }
 
 export function moveProperty(

--- a/src/utils/mergeQuery/utils.ts
+++ b/src/utils/mergeQuery/utils.ts
@@ -38,7 +38,7 @@ export function handleArray(
   _set(target, key, arr);
 }
 
-export function handleCircular<T>(
+export function handleCircular(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
   prependKey: Path,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "downlevelIteration": true,
     "sourceMap": false,
     "declaration": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "vitest/importMeta"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.js"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,12 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  define: {
+    "import.meta.vitest": "undefined",
+  },
   test: {
     globals: true,
+    includeSource: ["src/**/*.{js,ts}"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
This is a breaking change. The signature & behavior of `filterQuery` changed.

New implementation looks like this:
```ts
export function filterQuery<Q extends Query>(
  providedQuery?: Q,
): FilterQueryResult<Q> {
  providedQuery ??= {} as Q;
  const { $select, $limit, $skip, $sort, ...query } = providedQuery;

  const result: FilterQueryResult<Q> = { query } as any;

  if ("$select" in providedQuery) {
    result.$select = $select;
  }

  if ("$limit" in providedQuery) {
    result.$limit = $limit;
  }

  if ("$skip" in providedQuery) {
    result.$skip = $skip;
  }

  if ("$sort" in providedQuery) {
    result.$sort = $sort;
  }

  return result;
}
```